### PR TITLE
add getAll to return an array of objects with country and name

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,23 @@ exports.getName = function(code) {
 };
 
 /**
+ * Get all country information in an array of objects.
+ *
+ * Example:
+ *
+ *   // Returns an array [ { code: "AD", name: "ANDORA" }, ..., { code: "ZW", name: "ZIMBABWE" } ]
+ *   countrynames.getAll();
+ *
+ * @return {Array} All two-letter country codes and names defined in the ISO standard
+ * @api public
+ */
+exports.getAll = function() {
+    return Object.keys(fromCode).slice(1).sort().map(function(code, index){
+        return { 'code': code, 'name': fromCode[code] };
+    });
+}
+
+/**
  * Get a country name for a country code. Case-insensitive.
  *
  * Example:


### PR DESCRIPTION
This is pretty useful if you're doing something like building a country dropdown in jade. 

``` javascript
> countrynames.getAll()
[ { code: 'AD', name: 'ANDORRA' },
  { code: 'AE', name: 'UNITED ARAB EMIRATES' },
  { code: 'AF', name: 'AFGHANISTAN' },
  { code: 'AG', name: 'ANTIGUA AND BARBUDA' },
  { code: 'AI', name: 'ANGUILLA' },
  { code: 'AL', name: 'ALBANIA' },
  { code: 'AM', name: 'ARMENIA' },
  { code: 'AO', name: 'ANGOLA' },
  ...
```
